### PR TITLE
feat: 敵AIにステートマシンを実装

### DIFF
--- a/Assets/Scripts/Character/Enemy/AI/EnemyAIBrain.cs
+++ b/Assets/Scripts/Character/Enemy/AI/EnemyAIBrain.cs
@@ -1,21 +1,142 @@
 using Fusion;
-using System;
+using UnityEngine;
 
 public class EnemyAIBrain : NetworkBehaviour
 {
+    // AIの状態定義
     enum AIState
     {
-        Idle,
-        Patrol,
-        Chase,
-        Attack,
-        Flee
+        Idle,    // 待機
+        Chase,   // 追跡
+        Attack,  // 攻撃
     }
 
-    private AIState _currentState;
+    [Header("AI設定")]
+    [SerializeField] private float _chaseRange = 15f; // 追跡開始距離
+    [SerializeField] private float _attackRange = 5f; // 攻撃開始距離
+    [SerializeField] private LayerMask _targetLayer; // ターゲットのレイヤー
 
-    // 戦艦追跡・攻撃ロジック
-    private void ApproachBattleship() { }
-    private void ExecuteAttack() { }
-    private void HandleRetreat() { }
+    // 内部コンポーネントと状態
+    private BaseEnemy _enemy;
+    private Transform _target;
+
+    [Networked]
+    private AIState _currentState { get; set; }
+
+    public override void Spawned()
+    {
+        _enemy = GetComponent<BaseEnemy>();
+        if (_enemy == null)
+        {
+            Debug.LogError("BaseEnemy component not found on this GameObject.", this);
+        }
+        _currentState = AIState.Idle;
+    }
+
+    public override void FixedUpdateNetwork()
+    {
+        if (!HasStateAuthority) return;
+
+        // ターゲットがいない場合は探す
+        if (_target == null)
+        {
+            SearchForTarget();
+        }
+
+        // 状態に応じた行動を実行
+        switch (_currentState)
+        {
+            case AIState.Idle:
+                UpdateIdleState();
+                break;
+            case AIState.Chase:
+                UpdateChaseState();
+                break;
+            case AIState.Attack:
+                UpdateAttackState();
+                break;
+        }
+    }
+
+    // --- 状態ごとの処理 ---
+
+    private void UpdateIdleState()
+    {
+        // ターゲットを発見したら追跡状態に移行
+        if (_target != null)
+        {
+            _currentState = AIState.Chase;
+        }
+    }
+
+    private void UpdateChaseState()
+    {
+        if (_target == null)
+        {
+            _currentState = AIState.Idle;
+            return;
+        }
+
+        float distanceToTarget = Vector3.Distance(transform.position, _target.position);
+
+        // 攻撃範囲に入ったら攻撃状態に移行
+        if (distanceToTarget <= _attackRange)
+        {
+            _currentState = AIState.Attack;
+        }
+        else
+        {
+            // ターゲットに向かって移動
+            Vector3 direction = (_target.position - transform.position).normalized;
+            _enemy.MoveTo(direction);
+            DoRotation(direction);
+        }
+    }
+
+    private void UpdateAttackState()
+    {
+        if (_target == null)
+        {
+            _currentState = AIState.Idle;
+            return;
+        }
+
+        float distanceToTarget = Vector3.Distance(transform.position, _target.position);
+
+        // 攻撃範囲から出たら追跡状態に戻る
+        if (distanceToTarget > _attackRange)
+        {
+            _currentState = AIState.Chase;
+        }
+        else
+        {
+            // ターゲットの方向を向く
+            Vector3 direction = (_target.position - transform.position).normalized;
+            DoRotation(direction);
+            // 攻撃実行
+            _enemy.AttackTarget();
+        }
+    }
+
+    // --- 補助メソッド ---
+
+    private void SearchForTarget()
+    {
+        //索敵範囲内のターゲットを検索
+        Collider[] targets = Physics.OverlapSphere(transform.position, _chaseRange, _targetLayer);
+        if (targets.Length > 0)
+        {
+            // 最初に見つけたターゲットを設定
+            _target = targets[0].transform;
+        }
+    }
+
+    private void DoRotation(Vector3 targetDirection)
+    {
+        targetDirection.y = 0f;
+        if (targetDirection.sqrMagnitude > 0.01f)
+        {
+            transform.rotation = Quaternion.LookRotation(targetDirection.normalized);
+        }
+    }
 }

--- a/Assets/Scripts/Character/Enemy/Core/BaseEnemy.cs
+++ b/Assets/Scripts/Character/Enemy/Core/BaseEnemy.cs
@@ -17,12 +17,36 @@ public abstract class BaseEnemy : NetworkBehaviour
     // AI状態管理
     protected Transform _targetBattleship; // 戦艦のターゲット
     protected EnemyAIBrain _enemyAI; // AI行動制御
+    protected Rigidbody _rigidbody;
 
     // 死亡時のイベント
     public event Action<BaseEnemy, Vector3> OnDeath; // 死亡イベント
 
+    protected virtual void Awake()
+    {
+        _enemyAI = GetComponent<EnemyAIBrain>();
+        _rigidbody = GetComponent<Rigidbody>();
+    }
+
     public abstract void Initialize(); // 敵固有の初期化
     public abstract void AttackTarget(); // 攻撃実行
+
+    /// <summary>
+    /// 指定された方向へ移動します。
+    /// </summary>
+    /// <param name="direction">移動する方向</param>
+    public void MoveTo(Vector3 direction)
+    {
+        if (_rigidbody != null)
+        {
+            _rigidbody.velocity = direction * _moveSpeed;
+        }
+        else
+        {
+            // Rigidbodyがない場合はTransformを直接操作（フォールバック）
+            transform.position += direction * _moveSpeed * Runner.DeltaTime;
+        }
+    }
 
     public void Death()
     {


### PR DESCRIPTION
敵AIの行動制御をステートマシンベースに刷新しました。

- `EnemyAIBrain`に`Idle`, `Chase`, `Attack`のステートを定義し、状態遷移ロジックを実装。AIの意思決定をこのクラスに集約。
- `BaseEnemy`にAIからの移動命令を受け付ける`MoveTo`メソッドを追加。
- `EnemyWakame`からAIロジックを削除し、具体的な攻撃アクションのみに責務を限定。

これにより、AIの思考と行動が分離され、拡張性とメンテナンス性が向上しました。

<!-- GitHub Copilot　コードレビューへの指示：プルリクエストをレビューしてコメントをする際には日本語でお願いします。助長な部分があれば指摘お願いします。-->
